### PR TITLE
Point to hostnames 2.0 version

### DIFF
--- a/AppLensV2/Helpers/SupportObserverClient.cs
+++ b/AppLensV2/Helpers/SupportObserverClient.cs
@@ -118,7 +118,7 @@ namespace AppLensV2
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 client.DefaultRequestHeaders.Add("client-hash", SignData(string.Format("{{\"site\":\"{0}\"}}", siteName), SimpleHashAuthenticationHashKey));
 
-                var response = await client.GetAsync(SupportObserverApiEndpoint + "sites/" + siteName + "/hostnames");
+                var response = await client.GetAsync(SupportObserverApiEndpoint + "sites/" + siteName + "/hostnames?api-version=2.0");
 
                 if (response.IsSuccessStatusCode)
                 {

--- a/AppLensV2/app/Common/SiteService.ts
+++ b/AppLensV2/app/Common/SiteService.ts
@@ -16,15 +16,7 @@ module SupportCenter {
             var self = this;
             this.promise = this.$http.get("/api/sites/" + siteName).success(function (data: any) {
 
-                var hostNameList: string[] = [];
-                for (let hostname of data.HostNames) {
-                    if (hostname.SiteType === 0)    // non scm hostname
-                    {
-                        hostNameList.push(hostname.Name)
-                    }
-                }
-
-                self.site = new Site(data.Details[0].SiteName, data.Details[0].SubscriptionName, "internal_rg", hostNameList, data.Stamp.Name);
+                self.site = new Site(data.Details[0].SiteName, data.Details[0].SubscriptionName, "internal_rg", data.HostNames, data.Stamp.Name);
                 
                 self.$http({
                     method: "GET",


### PR DESCRIPTION
Previously observer HostNames API would return an incomplete list of hostnames. See Issue #145. Which would would give incomplete data for abnormal time periods.
And now HostNames API will return the correct list of hostnames pertaining to a given site or hostname.

eg., GET https://support-bay-api.azurewebsites.net/observer/sites/batman-node-v3-eastus2/hostnames?api-version=2.0

[
  "batman-node-v3-eastus2.azurewebsites.net",
  "jet.com",
  "www.jet.com"
]

