### PR TITLE
Ase with same friendly name support

### DIFF
--- a/AppLensV2/Controllers/SitesController.cs
+++ b/AppLensV2/Controllers/SitesController.cs
@@ -30,11 +30,9 @@ namespace AppLensV2
         [Route("api/sites/{siteName}")]
         public async Task<IHttpActionResult> GetSite(string siteName)
         {
-            var stampTask = SupportObserverClient.GetStamp(siteName);
             var hostnamesTask = SupportObserverClient.GetHostnames(siteName);
             var siteDetailsTask = SupportObserverClient.GetSite(siteName);
 
-            var stampResponse = await stampTask;
             var hostNameResponse = await hostnamesTask;
             var siteDetailsResponse = await siteDetailsTask;
 
@@ -46,11 +44,6 @@ namespace AppLensV2
             if (hostNameResponse.StatusCode != HttpStatusCode.OK)
             {
                 return ResponseMessage(Request.CreateErrorResponse(hostNameResponse.StatusCode, (string)hostNameResponse.Content));
-            }
-
-            if (stampResponse.StatusCode != HttpStatusCode.OK)
-            {
-                return ResponseMessage(Request.CreateErrorResponse(stampResponse.StatusCode, (string)stampResponse.Content));
             }
             
             var resourceGroupResponse =  await SupportObserverClient.GetResourceGroup((string)siteDetailsResponse.Content.First.SiteName);
@@ -66,7 +59,6 @@ namespace AppLensV2
             {
                 SiteName = siteName,
                 Details = siteDetailsResponse.Content,
-                Stamp = stampResponse.Content,
                 HostNames = hostNameResponse.Content
             });
         }

--- a/AppLensV2/Controllers/SitesController.cs
+++ b/AppLensV2/Controllers/SitesController.cs
@@ -27,11 +27,23 @@ namespace AppLensV2
         }
 
         [HttpGet]
+        [Route("api/stamps/{stamp}/sites/{siteName}")]
+        public async Task<IHttpActionResult> GetSite(string stamp, string siteName)
+        {
+            return await GetSiteInternal(stamp, siteName);
+        }
+
+        [HttpGet]
         [Route("api/sites/{siteName}")]
         public async Task<IHttpActionResult> GetSite(string siteName)
         {
+            return await GetSiteInternal(null, siteName);
+        }
+
+        private async Task<IHttpActionResult> GetSiteInternal(string stamp, string siteName)
+        {
             var hostnamesTask = SupportObserverClient.GetHostnames(siteName);
-            var siteDetailsTask = SupportObserverClient.GetSite(siteName);
+            var siteDetailsTask = stamp == null ? SupportObserverClient.GetSite(siteName) : SupportObserverClient.GetSite(stamp, siteName);
 
             var hostNameResponse = await hostnamesTask;
             var siteDetailsResponse = await siteDetailsTask;
@@ -45,8 +57,8 @@ namespace AppLensV2
             {
                 return ResponseMessage(Request.CreateErrorResponse(hostNameResponse.StatusCode, (string)hostNameResponse.Content));
             }
-            
-            var resourceGroupResponse =  await SupportObserverClient.GetResourceGroup((string)siteDetailsResponse.Content.First.SiteName);
+
+            var resourceGroupResponse = await SupportObserverClient.GetResourceGroup((string)siteDetailsResponse.Content.First.SiteName);
 
             if (resourceGroupResponse.StatusCode != HttpStatusCode.OK)
             {

--- a/AppLensV2/Controllers/SitesController.cs
+++ b/AppLensV2/Controllers/SitesController.cs
@@ -58,15 +58,6 @@ namespace AppLensV2
                 return ResponseMessage(Request.CreateErrorResponse(hostNameResponse.StatusCode, (string)hostNameResponse.Content));
             }
 
-            var resourceGroupResponse = await SupportObserverClient.GetResourceGroup((string)siteDetailsResponse.Content.First.SiteName);
-
-            if (resourceGroupResponse.StatusCode != HttpStatusCode.OK)
-            {
-                return ResponseMessage(Request.CreateErrorResponse(siteDetailsResponse.StatusCode, (string)siteDetailsResponse.Content));
-            }
-
-            siteDetailsResponse.Content.First.ResourceGroupName = resourceGroupResponse.Content;
-
             return Ok(new
             {
                 SiteName = siteName,

--- a/AppLensV2/Helpers/SupportObserverClient.cs
+++ b/AppLensV2/Helpers/SupportObserverClient.cs
@@ -106,17 +106,31 @@ namespace AppLensV2
         /// Get site details for siteName
         /// </summary>
         /// <param name="siteName">Site Name</param>
-        /// <returns>Stamp</returns>
         internal static async Task<ObserverResponse> GetSite(string siteName)
+        {
+            return await GetSiteInternal(SupportObserverApiEndpoint + "sites/" + siteName + "/adminsites?api-version=2.0", string.Format("{{\"site\":\"{0}\"}}", siteName));
+        }
+
+        /// <summary>
+        /// Get site details for siteName
+        /// </summary>
+        /// <param name="stamp">Stamp</param>
+        /// <param name="siteName">Site Name</param>
+        internal static async Task<ObserverResponse> GetSite(string stamp, string siteName)
+        {
+            return await GetSiteInternal(SupportObserverApiEndpoint + "stamps/" + stamp + "/sites/" + siteName + "/adminsites?api-version=2.0",
+                string.Format("{{\"stamp\":\"{0}\",\"site\":\"{1}\"}}", stamp, siteName));
+        }
+
+        private static async Task<ObserverResponse> GetSiteInternal(string endpoint, string hashInput)
         {
             var request = new HttpRequestMessage()
             {
-                RequestUri = new Uri(SupportObserverApiEndpoint + "sites/" + siteName + "/adminsites?api-version=2.0"),
+                RequestUri = new Uri(endpoint),
                 Method = HttpMethod.Get
             };
-
-            var serializedParameters = JsonConvert.SerializeObject(new Dictionary<string, string>() { { "site", siteName } });
-            request.Headers.Add("client-hash", SignData(string.Format("{{\"site\":\"{0}\"}}", siteName), SimpleHashAuthenticationHashKey));
+            
+            request.Headers.Add("client-hash", SignData(hashInput, SimpleHashAuthenticationHashKey));
             var response = await _httpClient.SendAsync(request);
 
             ObserverResponse res = await CreateObserverResponse(response, "GetAdminSite");

--- a/AppLensV2/app/Common/Constants.ts
+++ b/AppLensV2/app/Common/Constants.ts
@@ -28,7 +28,7 @@ module SupportCenter {
         private static detectorFeedback: string = "/api/detectors/{detectorName}/feedback";
 
         public static SiteDetailsPath(params: IStateParams): string {
-            if (angular.isDefined(params.stamp)) {
+            if (angular.isDefined(params.stamp) && params.stamp !== '') {
                 return UriPaths.siteDetailsWithStamp.replace("{stamp}", params.stamp).replace("{siteName}", params.siteName);
             } else {
                 return UriPaths.siteDetails.replace("{siteName}", params.siteName);

--- a/AppLensV2/app/Common/Constants.ts
+++ b/AppLensV2/app/Common/Constants.ts
@@ -78,7 +78,7 @@ module SupportCenter {
                 .replace("{sub}", site.subscriptionId)
                 .replace("{rg}", site.resourceGroup)
                 .replace("{site}", site.name)
-                .replace("{stamp}", site.stampName)
+                .replace("{stamp}", site.internalStampName)
                 .replace("{start}", startTime)
                 .replace("{end}", endTime)
                 .replace("{grain}", timeGrain);

--- a/AppLensV2/app/Common/Constants.ts
+++ b/AppLensV2/app/Common/Constants.ts
@@ -11,6 +11,7 @@ module SupportCenter {
     export class UriPaths {
 
         private static siteDetails: string = "/api/sites/{siteName}";
+        private static siteDetailsWithStamp: string = "/api/stamps/{stamp}/sites/{siteName}";
         private static diagnosticsPassThroughApiPath: string = "/api/diagnostics";
         private static detectorsDocumentAPIPath: string = "/api/detectors/{detectorName}/files/{fileName}";
 
@@ -26,8 +27,12 @@ module SupportCenter {
         private static caseFeedback: string = "/api/cases/{caseId}/feedback";
         private static detectorFeedback: string = "/api/detectors/{detectorName}/feedback";
 
-        public static SiteDetailsPath(siteName: string): string {
-            return UriPaths.siteDetails.replace("{siteName}", siteName);
+        public static SiteDetailsPath(params: IStateParams): string {
+            if (angular.isDefined(params.stamp)) {
+                return UriPaths.siteDetailsWithStamp.replace("{stamp}", params.stamp).replace("{siteName}", params.siteName);
+            } else {
+                return UriPaths.siteDetails.replace("{siteName}", params.siteName);
+            }
         }
 
         public static DiagnosticsPassThroughAPIPath(): string {

--- a/AppLensV2/app/Common/IStateParams.ts
+++ b/AppLensV2/app/Common/IStateParams.ts
@@ -4,6 +4,7 @@ module SupportCenter {
     "use strict";
 
     export interface IStateParams extends angular.ui.IStateParamsService {
+        stamp: string;
         siteName: string;
         startTime: string;
         endTime: string;

--- a/AppLensV2/app/Common/SiteService.ts
+++ b/AppLensV2/app/Common/SiteService.ts
@@ -13,9 +13,9 @@ module SupportCenter {
 
         static $inject = ['$http', '$stateParams', 'ErrorHandlerService'];
         constructor(private $http: ng.IHttpService, private $stateParams: IStateParams, private ErrorHandlerService: IErrorHandlerService) {
-            let siteName = $stateParams.siteName;
             var self = this;
-            this.promise = this.$http.get("/api/sites/" + siteName)
+
+            this.promise = this.$http.get(UriPaths.SiteDetailsPath(this.$stateParams))
                 .success(function (data: any) {
 
                     self.sites = new Array<Site>();

--- a/AppLensV2/app/Common/SiteService.ts
+++ b/AppLensV2/app/Common/SiteService.ts
@@ -18,12 +18,14 @@ module SupportCenter {
             this.promise = this.$http.get("/api/sites/" + siteName)
                 .success(function (data: any) {
 
-                    self.site = new Site(data.Details[0].SiteName, data.Details[0].Subscription, data.Details[0].ResourceGroupName, data.HostNames, data.Stamp.Name);
-
                     self.sites = new Array<Site>();
+
                     for (let siteDetail of data.Details) {
                         self.sites.push(new Site(siteDetail.SiteName, siteDetail.Subscription, siteDetail.ResourceGroupName, data.HostNames, siteDetail.StampName));
                     }
+
+                    //if the array is empty then the observer call will fail before it gets to this line with a 404 SiteNotFound
+                    self.site = self.sites[0];
 
                     self.$http({
                         method: "GET",

--- a/AppLensV2/app/Common/SiteService.ts
+++ b/AppLensV2/app/Common/SiteService.ts
@@ -21,7 +21,7 @@ module SupportCenter {
                     self.sites = new Array<Site>();
 
                     for (let siteDetail of data.Details) {
-                        self.sites.push(new Site(siteDetail.SiteName, siteDetail.Subscription, siteDetail.ResourceGroupName, data.HostNames, siteDetail.InternalStampName));
+                        self.sites.push(new Site(siteDetail.SiteName, siteDetail.Subscription, siteDetail.ResourceGroupName, data.HostNames, siteDetail.StampName, siteDetail.InternalStampName));
                     }
 
                     //if the array is empty then the observer call will fail before it gets to this line with a 404 SiteNotFound

--- a/AppLensV2/app/Common/SiteService.ts
+++ b/AppLensV2/app/Common/SiteService.ts
@@ -21,7 +21,7 @@ module SupportCenter {
                     self.sites = new Array<Site>();
 
                     for (let siteDetail of data.Details) {
-                        self.sites.push(new Site(siteDetail.SiteName, siteDetail.Subscription, siteDetail.ResourceGroupName, data.HostNames, siteDetail.StampName));
+                        self.sites.push(new Site(siteDetail.SiteName, siteDetail.Subscription, siteDetail.ResourceGroupName, data.HostNames, siteDetail.InternalStampName));
                     }
 
                     //if the array is empty then the observer call will fail before it gets to this line with a 404 SiteNotFound

--- a/AppLensV2/app/Main/MainCtrl.ts
+++ b/AppLensV2/app/Main/MainCtrl.ts
@@ -79,13 +79,12 @@ module SupportCenter {
             });
 
             // if no child route is defined, then set default child route to sia
-            if (this.$state.current.name === 'home') {
+            if (this.$state.current.name.indexOf('home') >= 0) {
                 this.setSelectedItem('sia');
             }
-
-            if (this.$state.current.name === 'home.sia') {
+            if (this.$state.current.name.indexOf('.sia') >= 0) {
                 this.selectedItem = "sia";
-            } else if (this.$state.current.name === 'home.detector') {
+            } else if (this.$state.current.name.indexOf('.detector') >= 0) {
                 this.selectedItem = this.$state.params['detectorName'];
             }
         }
@@ -108,15 +107,22 @@ module SupportCenter {
         setSelectedItem(name: string): void {
             if (name === 'sia') {
                 this.selectedItem = "sia";
-
-                if (this.$state.current.name !== 'home.sia') {
+                if (this.$state.current.name.indexOf('home2') >= 0) {
+                    this.$state.go('home2.sia');
+                } else {
                     this.$state.go('home.sia');
                 }
             }
             else {
                 this.selectedItem = name;
-                if ((this.$state.current.name !== 'home.detector') || (this.$state.current.name === 'home.detector' && this.$state.params['detectorName'] !== name)) {
-                    this.$state.go('home.detector', { detectorName: name });
+                if (this.$state.current.name.indexOf('home2') >= 0) {
+                    if ((this.$state.current.name !== 'home2.detector') || (this.$state.current.name === 'home2.detector' && this.$state.params['detectorName'] !== name)) {
+                        this.$state.go('home2.detector', { detectorName: name });
+                    }
+                } else {
+                    if ((this.$state.current.name !== 'home.detector') || (this.$state.current.name === 'home.detector' && this.$state.params['detectorName'] !== name)) {
+                        this.$state.go('home.detector', { detectorName: name });
+                    }
                 }
             }
 
@@ -251,7 +257,7 @@ module SupportCenter {
 
                 self.properties.push(new NameValuePair("Subscription Id", self.site.subscriptionId));
                 self.properties.push(new NameValuePair("Resource Group", self.site.resourceGroup));
-                self.properties.push(new NameValuePair("Stamp Name", self.site.stampName));
+                self.properties.push(new NameValuePair("Stamp Name", self.site.internalStampName));
                 self.properties.push(new NameValuePair("Hostnames", self.site.hostNames.join()));
                 self.properties.push(new NameValuePair("App Stack", self.site.stack));
                 self.properties.push(new NameValuePair("SKU", self.site.sku));

--- a/AppLensV2/app/Main/main.html
+++ b/AppLensV2/app/Main/main.html
@@ -209,10 +209,11 @@
             <md-list-item class="md-2-line" ng-repeat="site in multiplesitesctrl.sites">
                 <div class="md-list-item-text" layout="column">
                     <h2 style="margin-bottom: 0 !important">{{::site.name}}</h2>
-                    <h3>{{::site.stampName}}</h3>
+                    <h3>Stamp Name: {{::site.stampName}}</h3>
+                    <h3 ng-hide="{{site.stampName == site.internalStampName}}">Internal Stamp Name: {{::site.internalStampName}}</h3>
                 </div>
                 <md-button class="md-secondary">
-                    <a ng-click="multiplesitesctrl.chooseSite(site.name)">Go</a>
+                    <a ng-click="multiplesitesctrl.chooseSite(site)">Go</a>
                 </md-button>
             </md-list-item>
         </md-list>

--- a/AppLensV2/app/Main/main.html
+++ b/AppLensV2/app/Main/main.html
@@ -210,7 +210,7 @@
                 <div class="md-list-item-text" layout="column">
                     <h2 style="margin-bottom: 0 !important">{{::site.name}}</h2>
                     <h3>Stamp Name: {{::site.stampName}}</h3>
-                    <h3 ng-hide="{{site.stampName == site.internalStampName}}">Internal Stamp Name: {{::site.internalStampName}}</h3>
+                    <h3 ng-hide="{{site.stampName === site.internalStampName}}">Internal Stamp Name: {{::site.internalStampName}}</h3>
                 </div>
                 <md-button class="md-secondary">
                     <a ng-click="multiplesitesctrl.chooseSite(site)">Go</a>

--- a/AppLensV2/app/MultipleSitesDialog/MultipleSitesDialogCtrl.ts
+++ b/AppLensV2/app/MultipleSitesDialog/MultipleSitesDialogCtrl.ts
@@ -15,8 +15,9 @@
             var appLensUrl = locationService.href;
             var oldValue = this.$stateParams.siteName;
             var newValue = site.name;
-            appLensUrl = appLensUrl.replace(oldValue, newValue);
-            if (this.sites[0].name != site.name) {
+            appLensUrl = locationService.origin + "/stamps/" + site.internalStampName + locationService.pathname.replace(oldValue, newValue) +
+                locationService.search;
+            if (this.sites[0].name != site.name && this.sites[0].internalStampName != site.internalStampName) {
                 this.$window.open(appLensUrl);
             } else {
                 locationService.replace(appLensUrl);

--- a/AppLensV2/app/MultipleSitesDialog/MultipleSitesDialogCtrl.ts
+++ b/AppLensV2/app/MultipleSitesDialog/MultipleSitesDialogCtrl.ts
@@ -17,7 +17,7 @@
             var newValue = site.name;
             appLensUrl = locationService.origin + "/stamps/" + site.internalStampName + locationService.pathname.replace(oldValue, newValue) +
                 locationService.search;
-            if (this.sites[0].name != site.name && this.sites[0].internalStampName != site.internalStampName) {
+            if (this.sites[0].name !== site.name && this.sites[0].internalStampName !== site.internalStampName) {
                 this.$window.open(appLensUrl);
             } else {
                 locationService.replace(appLensUrl);

--- a/AppLensV2/app/MultipleSitesDialog/MultipleSitesDialogCtrl.ts
+++ b/AppLensV2/app/MultipleSitesDialog/MultipleSitesDialogCtrl.ts
@@ -10,13 +10,13 @@
             });
         }
 
-        chooseSite(sitename: string): void {
+        chooseSite(site: Site): void {
             let locationService = this.$window.location;
             var appLensUrl = locationService.href;
             var oldValue = this.$stateParams.siteName;
-            var newValue = sitename;
+            var newValue = site.name;
             appLensUrl = appLensUrl.replace(oldValue, newValue);
-            if (this.sites[0].name != sitename) {
+            if (this.sites[0].name != site.name) {
                 this.$window.open(appLensUrl);
             } else {
                 locationService.replace(appLensUrl);

--- a/AppLensV2/app/NgModels/Site.ts
+++ b/AppLensV2/app/NgModels/Site.ts
@@ -9,7 +9,8 @@ module SupportCenter {
             public subscriptionId: string,
             public resourceGroup: string,
             public hostNames: string[],
-            public stampName: string
+            public stampName: string,
+            public internalStampName: string
         ) {
         }
 

--- a/AppLensV2/app/app.ts
+++ b/AppLensV2/app/app.ts
@@ -45,6 +45,12 @@ module SupportCenter {
                     controller: 'MainCtrl',
                     controllerAs: 'main'
                 })
+                .state('home2', {
+                    url: '/stamps/{stamp}/sites/{siteName}?{startTime}&{endTime}&{timeGrain}',
+                    templateUrl: 'app/Main/main.html',
+                    controller: 'MainCtrl',
+                    controllerAs: 'main'
+                })
                 .state('home.sia', {
                     url: '/appanalysis',
                     views: {
@@ -55,7 +61,27 @@ module SupportCenter {
                         }
                     }
                 })
+                .state('home2.sia', {
+                    url: '/appanalysis',
+                    views: {
+                        'childContent': {
+                            templateUrl: 'app/Sia/sia.html',
+                            controller: 'SiaCtrl',
+                            controllerAs: 'sia'
+                        }
+                    }
+                })
                 .state('home.detector', {
+                    url: '/detectors/{detectorName}',
+                    views: {
+                        'childContent': {
+                            templateUrl: 'app/Detector/detector.html',
+                            controller: 'DetectorCtrl',
+                            controllerAs: 'detector'
+                        }
+                    }
+                })
+                .state('home2.detector', {
                     url: '/detectors/{detectorName}',
                     views: {
                         'childContent': {


### PR DESCRIPTION
+URL changes when having to choose between site that lands in multiple stamps.
eg., sites/jet.com/appanalysis -> select one of the sites -> URL now looks like stamps/{stamp}/sites/{site}/appanalysis
+Make call to new observer admin sites API which takes site name and stamp name

note for some reason I get this error: SideNav 'left' is not available! Did you use md-component-id='left'?
Although when I run AppLens on my local machine the sideNav is working perfectly...

