### PR TITLE
Adding Metric name with Role Instance in graph

### DIFF
--- a/AppLensV2/app/Detector/DetectorViewHelper.ts
+++ b/AppLensV2/app/Detector/DetectorViewHelper.ts
@@ -108,7 +108,7 @@ module SupportCenter {
                     if (!angular.isDefined(workerChartData[workerName])) {
 
                         workerChartData[workerName] = {
-                            key: workerName === Constants.aggregatedWorkerName ? metric.Name: workerName,
+                            key: workerName === Constants.aggregatedWorkerName ? metric.Name : workerName + '(' + metric.Name + ')',
                             worker: workerName,
                             isActive: true,
                             values: [],


### PR DESCRIPTION
When metric per role instance is shown in graph, Right now it only shows RoleInstance name in the graph, not the metric name. This can be confusing if you have multiple metrics per role instance.
For instance, I am adding w3wp start and w3wp stop metrics per role instance. the graph right now shows two lines labelled as RoleInstance name but no metric name.