### PR TITLE
Enable sia for ase

### DIFF
--- a/AppLensV2/AppLensV2.csproj
+++ b/AppLensV2/AppLensV2.csproj
@@ -212,6 +212,11 @@
     <TypeScriptCompile Include="app\NgModels\SiaResponse.ts" />
     <TypeScriptCompile Include="app\NgModels\Site.ts" />
     <TypeScriptCompile Include="app\references.ts" />
+    <TypeScriptCompile Include="app\Sia\AnalysisResponse\AnalysisResponseFactory.ts" />
+    <TypeScriptCompile Include="app\Sia\AnalysisResponse\AseAvailabilityAnalysisResponse.ts" />
+    <TypeScriptCompile Include="app\Sia\AnalysisResponse\IAnalysisResponse.ts" />
+    <TypeScriptCompile Include="app\Sia\AnalysisResponse\AppAnalysisResponse.ts" />
+    <TypeScriptCompile Include="app\Sia\AnalysisResponse\PerfAnalysisResponse.ts" />
     <TypeScriptCompile Include="app\Sia\SiaCtrl.ts" />
     <TypeScriptCompile Include="app\Site\SiteCtrl.ts" />
   </ItemGroup>

--- a/AppLensV2/AppLensV2.csproj
+++ b/AppLensV2/AppLensV2.csproj
@@ -191,6 +191,7 @@
     <TypeScriptCompile Include="app\Common\ErrorHandlerService.ts" />
     <TypeScriptCompile Include="app\Common\FeedbackService.ts" />
     <TypeScriptCompile Include="app\Common\IStateParams.ts" />
+    <TypeScriptCompile Include="app\Common\ResourceServiceFactory.ts" />
     <TypeScriptCompile Include="app\Common\SiaService.ts" />
     <TypeScriptCompile Include="app\Common\AseService.ts" />
     <TypeScriptCompile Include="app\Common\SiteService.ts" />

--- a/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
+++ b/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
@@ -53,7 +53,7 @@ module SupportCenter {
                         var siaResponse = data.Response;
                         _.each(siaResponse.NonCorrelatedDetectors, function (item: DetectorDefinition) {
                             _.each(self.DetectorsService.detectorsList, function (detector: DetectorDefinition) {
-                                if (item.DisplayName == detector.DisplayName) {
+                                if (item.DisplayName === detector.DisplayName) {
                                     detector.Correlated = 0;
                                 }
                             });
@@ -61,7 +61,7 @@ module SupportCenter {
 
                         _.each(siaResponse.Payload, function (item: AnalysisData) {
                             _.each(self.DetectorsService.detectorsList, function (detector: DetectorDefinition) {
-                                if (item.DetectorDefinition.DisplayName == detector.DisplayName) {
+                                if (item.DetectorDefinition.DisplayName === detector.DisplayName) {
                                     detector.Correlated = 1;
                                 }
                             });

--- a/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
+++ b/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
@@ -61,7 +61,7 @@ module SupportCenter {
             });
 
             //if no child route is defined, then set default child route to sia
-            if (this.$state.current.name === "home3") {
+            if (this.$state.current.name === "home3" || this.$state.current.name === "home3.aseAvailabilityAnalysis") {
                 this.setSelectedItem("sia");
             }
             else {

--- a/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
+++ b/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
@@ -49,6 +49,27 @@ module SupportCenter {
                 self.DetectorsService.getDetectors(self.hostingEnvironment).then(function (data: DetectorDefinition[]) {
                     self.detectors = data;
                     self.detectorListLoaded = true;
+                    self.SiaService.getSiaResponse().then(function (data: IAnalysisResult) {
+                        var siaResponse = data.Response;
+                        _.each(siaResponse.NonCorrelatedDetectors, function (item: DetectorDefinition) {
+                            _.each(self.DetectorsService.detectorsList, function (detector: DetectorDefinition) {
+                                if (item.DisplayName == detector.DisplayName) {
+                                    detector.Correlated = 0;
+                                }
+                            });
+                        });
+
+                        _.each(siaResponse.Payload, function (item: AnalysisData) {
+                            _.each(self.DetectorsService.detectorsList, function (detector: DetectorDefinition) {
+                                if (item.DetectorDefinition.DisplayName == detector.DisplayName) {
+                                    detector.Correlated = 1;
+                                }
+                            });
+                        });
+                    }, function (err) {
+                        // Error in App Analysis
+                        self.ErrorHandlerService.showError(ErrorModelBuilder.Build(err));
+                    });
                 }, function (err) {
                     self.detectorListLoaded = true;
                     self.ErrorHandlerService.showError(ErrorModelBuilder.Build(err));
@@ -87,7 +108,7 @@ module SupportCenter {
         setSelectedItem(name: string): void {
             this.selectedItem = name;
             if (name === 'sia') {
-                this.$state.go('home3.aseAvailabilityAnalysis.sia')
+                this.$state.go('home3.sia')
             }
             else {
                 if (this.$state.current.name.indexOf('home3') >= 0) {

--- a/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
+++ b/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
@@ -108,7 +108,7 @@ module SupportCenter {
         setSelectedItem(name: string): void {
             this.selectedItem = name;
             if (name === 'sia') {
-                this.$state.go('home3.sia')
+                this.$state.go('home3.aseAvailabilityAnalysis')
             }
             else {
                 if (this.$state.current.name.indexOf('home3') >= 0) {

--- a/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
+++ b/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
@@ -61,8 +61,11 @@ module SupportCenter {
             });
 
             //if no child route is defined, then set default child route to sia
-            if (this.$state.current.name.indexOf('.detector') >= 0) {
-                this.selectedItem = this.$state.params['detectorName'];
+            if (this.$state.current.name === "home3") {
+                this.setSelectedItem("sia");
+            }
+            else {
+                this.setSelectedItem(this.$state.params['detectorName']);
             }
         }
 
@@ -82,16 +85,11 @@ module SupportCenter {
         }
 
         setSelectedItem(name: string): void {
+            this.selectedItem = name;
             if (name === 'sia') {
-                this.selectedItem = "sia";
-                if (this.$state.current.name.indexOf('home2') >= 0) {
-                    this.$state.go('home2.sia');
-                } else {
-                    this.$state.go('home.sia');
-                }
+                this.$state.go('home3.aseAvailabilityAnalysis.sia')
             }
             else {
-                this.selectedItem = name;
                 if (this.$state.current.name.indexOf('home3') >= 0) {
                     if ((this.$state.current.name !== 'home3.detector') || (this.$state.current.name === 'home3.detector' && this.$state.params['detectorName'] !== name)) {
                         this.$state.go('home3.detector', { detectorName: name });

--- a/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
+++ b/AppLensV2/app/AppServiceEnvironment/AppServiceEnvironmentCtrl.ts
@@ -82,7 +82,7 @@ module SupportCenter {
             });
 
             //if no child route is defined, then set default child route to sia
-            if (this.$state.current.name === "home3" || this.$state.current.name === "home3.aseAvailabilityAnalysis") {
+            if (this.$state.current.name === "appServiceEnvironment" || this.$state.current.name === "appServiceEnvironment.aseAvailabilityAnalysis") {
                 this.setSelectedItem("sia");
             }
             else {
@@ -108,12 +108,12 @@ module SupportCenter {
         setSelectedItem(name: string): void {
             this.selectedItem = name;
             if (name === 'sia') {
-                this.$state.go('home3.aseAvailabilityAnalysis')
+                this.$state.go('appServiceEnvironment.aseAvailabilityAnalysis')
             }
             else {
-                if (this.$state.current.name.indexOf('home3') >= 0) {
-                    if ((this.$state.current.name !== 'home3.detector') || (this.$state.current.name === 'home3.detector' && this.$state.params['detectorName'] !== name)) {
-                        this.$state.go('home3.detector', { detectorName: name });
+                if (this.$state.current.name.indexOf('appServiceEnvironment') >= 0) {
+                    if ((this.$state.current.name !== 'appServiceEnvironment.detector') || (this.$state.current.name === 'appServiceEnvironment.detector' && this.$state.params['detectorName'] !== name)) {
+                        this.$state.go('appServiceEnvironment.detector', { detectorName: name });
                     }
                 }
             }

--- a/AppLensV2/app/AppServiceEnvironment/appServiceEnvironment.html
+++ b/AppLensV2/app/AppServiceEnvironment/appServiceEnvironment.html
@@ -153,15 +153,11 @@
             </md-card>
         </div>
 
-        <md-content flex layout="column">
+        <div flex layout="row">
 
-            <div flex layout="row">
+            <div flex ui-view="childContent"></div>
 
-                <div flex ui-view="childContent"></div>
-
-            </div>
-
-        </md-content>
+        </div>
 
     </md-content>
 </div>

--- a/AppLensV2/app/Common/Constants.ts
+++ b/AppLensV2/app/Common/Constants.ts
@@ -26,8 +26,7 @@ module SupportCenter {
         private static commonQueryString: string = "stampName={stamp}&{hostnames}&startTime={start}&endTime={end}&timeGrain={grain}";
         private static appAnalysis: string = "/appAnalysis?" + UriPaths.commonQueryString;
         private static perfAnalysis: string = "/perfAnalysis?" + UriPaths.commonQueryString;
-        //will remove 'detectors' from aseAvailabilityAnalysis once DiagRole API path is corrected
-        private static aseAvailabilityAnalysis: string = "/detectors/aseAvailabilityAnalysis?" + UriPaths.commonQueryString;
+        private static aseAvailabilityAnalysis: string = "/aseAvailabilityAnalysis?" + UriPaths.commonQueryString;
         private static detectors: string = "/detectors";
         private static detectorResource: string = "/detectors/{detectorName}?" + UriPaths.commonQueryString;
         private static siteDiagnosticProperties: string = "/properties";

--- a/AppLensV2/app/Common/Constants.ts
+++ b/AppLensV2/app/Common/Constants.ts
@@ -8,6 +8,7 @@ module SupportCenter {
         public static aggregatedWorkerName: string = "aggregated";
         public static perfAnalysis: string = "perfAnalysis";
         public static appAnalysis: string = "appAnalysis";
+        public static aseAvailabilityAnalysis: string = "aseAvailabilityAnalysis";
     }
 
     export class UriPaths {
@@ -25,6 +26,8 @@ module SupportCenter {
         private static commonQueryString: string = "stampName={stamp}&{hostnames}&startTime={start}&endTime={end}&timeGrain={grain}";
         private static appAnalysis: string = "/appAnalysis?" + UriPaths.commonQueryString;
         private static perfAnalysis: string = "/perfAnalysis?" + UriPaths.commonQueryString;
+        //will remove 'detectors' from aseAvailabilityAnalysis once DiagRole API path is corrected
+        private static aseAvailabilityAnalysis: string = "detectors/aseAvailabilityAnalysis?" + UriPaths.commonQueryString;
         private static detectors: string = "/detectors";
         private static detectorResource: string = "/detectors/{detectorName}?" + UriPaths.commonQueryString;
         private static siteDiagnosticProperties: string = "/properties";
@@ -87,6 +90,10 @@ module SupportCenter {
         public static DetectorResourcePath(resource: Resource, detectorName: string, startTime: string, endTime: string, timeGrain: string): string {
             return UriPaths.CreateGeoRegionAPIPath(UriPaths.detectorResource, resource, startTime, endTime, timeGrain)
                 .replace("{detectorName}", detectorName);
+        }
+
+        public static AseAvailabilityAnalysisPath(resource: Resource, startTime: string, endTime: string, timeGrain: string) {
+            return UriPaths.CreateGeoRegionAPIPath(UriPaths.aseAvailabilityAnalysis, resource, startTime, endTime, timeGrain);
         }
 
         private static CreateGeoRegionAPIPath(pathFormat: string, resource: Resource, startTime: string, endTime: string, timeGrain: string): string {

--- a/AppLensV2/app/Common/Constants.ts
+++ b/AppLensV2/app/Common/Constants.ts
@@ -27,7 +27,7 @@ module SupportCenter {
         private static appAnalysis: string = "/appAnalysis?" + UriPaths.commonQueryString;
         private static perfAnalysis: string = "/perfAnalysis?" + UriPaths.commonQueryString;
         //will remove 'detectors' from aseAvailabilityAnalysis once DiagRole API path is corrected
-        private static aseAvailabilityAnalysis: string = "detectors/aseAvailabilityAnalysis?" + UriPaths.commonQueryString;
+        private static aseAvailabilityAnalysis: string = "/detectors/aseAvailabilityAnalysis?" + UriPaths.commonQueryString;
         private static detectors: string = "/detectors";
         private static detectorResource: string = "/detectors/{detectorName}?" + UriPaths.commonQueryString;
         private static siteDiagnosticProperties: string = "/properties";

--- a/AppLensV2/app/Common/ResourceServiceFactory.ts
+++ b/AppLensV2/app/Common/ResourceServiceFactory.ts
@@ -1,0 +1,21 @@
+﻿module SupportCenter {
+    export class ResourceServiceFactory {
+        public static $inject: string[] = ["$http", "$stateParams", "ErrorHandlerService"]
+        constructor(private $http: ng.IHttpService, private $stateParams: IStateParams, private ErrorHandlerService: IErrorHandlerService) {
+        }
+
+        GetResourceService(): IResourceService {
+            let resourceService;
+            switch (this.$stateParams.analysisType) {
+                case Constants.appAnalysis:
+                case Constants.perfAnalysis:
+                    resourceService = new SiteService(this.$http, this.$stateParams, this.ErrorHandlerService);
+                    break;
+                case Constants.aseAvailabilityAnalysis:
+                    resourceService = new AseService(this.$http, this.$stateParams, this.ErrorHandlerService);
+                    break;
+            }
+            return resourceService;
+        }
+    }
+}

--- a/AppLensV2/app/Common/SiaService.ts
+++ b/AppLensV2/app/Common/SiaService.ts
@@ -31,8 +31,21 @@ module SupportCenter {
         }
 
         getSiaResponse(): ng.IPromise<IAnalysisResult> {
-            //return this.$stateParams.analysisType === 'perfAnalysis' ? this.getPerfAnalysisResponse() : this.getAppAnalysisResponse();
-            return this.AnalysisFactory.GetAnalysis().getAnalysisResponse();
+            let analysisType = this.$stateParams.analysisType;
+            var deferred = this.$q.defer<IAnalysisResult>();
+            var self = this;
+
+            if (angular.isDefined(this.analysisCache[analysisType].Promise) && this.analysisCache[analysisType].Promise !== null) {
+                this.analysisCache[analysisType].Promise.then(function (data: any) {
+                    self.analysisCache[analysisType].Response = data.Response;
+                    self.analysisCache[analysisType].SelectedAbnormalTimePeriod = data.SelectedAbnormalTimePeriod;
+                    deferred.resolve(self.analysisCache[analysisType])
+                });
+                return deferred.promise;
+            }else {
+                this.analysisCache[analysisType].Promise = this.AnalysisFactory.GetAnalysis().getAnalysisResponse();
+                return this.analysisCache[analysisType].Promise;
+            }
         }
 
         getAppAnalysisResponse(): ng.IPromise<IAnalysisResult> {
@@ -42,6 +55,7 @@ module SupportCenter {
             var analysisType = 'appAnalysis';
             if (angular.isDefined(this.analysisCache[analysisType].Promise) && this.analysisCache[analysisType].Promise !== null) {
                 this.analysisCache[analysisType].Promise.then(function (data: any) {
+                    
                     deferred.resolve(self.analysisCache[analysisType])
                 });
                 return deferred.promise;

--- a/AppLensV2/app/Common/SiaService.ts
+++ b/AppLensV2/app/Common/SiaService.ts
@@ -19,10 +19,10 @@ module SupportCenter {
         private analysisPromiseCache: ICache<ng.IPromise<any>>;
         private analysisResultCache: ICache<SiaResponse>;
 
-        public static $inject: string[] = ["SiteService", "DetectorsService", "TimeParamsService", "$http", "$q", "$window", "$state", "$stateParams"];
+        public static $inject: string[] = ["SiteService", "DetectorsService", "TimeParamsService", "$http", "$q", "$window", "$state", "$stateParams", "AnalysisResponseFactory"];
         public selectedAbnormalTimePeriod: any;
 
-        constructor(private SiteService: IResourceService, private DetectorsService: IDetectorsService, private TimeParamsService: ITimeParamsService, private $http: ng.IHttpService, private $q: ng.IQService, private $window: angular.IWindowService, private $state: angular.ui.IStateService, private $stateParams: IStateParams) {
+        constructor(private SiteService: IResourceService, private DetectorsService: IDetectorsService, private TimeParamsService: ITimeParamsService, private $http: ng.IHttpService, private $q: ng.IQService, private $window: angular.IWindowService, private $state: angular.ui.IStateService, private $stateParams: IStateParams, private AnalysisFactory: AnalysisResponseFactory) {
             this.analysisPromiseCache = {};
             this.analysisResultCache = {};
             this.analysisCache = {};
@@ -31,7 +31,8 @@ module SupportCenter {
         }
 
         getSiaResponse(): ng.IPromise<IAnalysisResult> {
-            return this.$stateParams.analysisType === 'perfAnalysis' ? this.getPerfAnalysisResponse() : this.getAppAnalysisResponse();
+            //return this.$stateParams.analysisType === 'perfAnalysis' ? this.getPerfAnalysisResponse() : this.getAppAnalysisResponse();
+            return this.AnalysisFactory.GetAnalysis().getAnalysisResponse();
         }
 
         getAppAnalysisResponse(): ng.IPromise<IAnalysisResult> {

--- a/AppLensV2/app/Common/ThemeService.ts
+++ b/AppLensV2/app/Common/ThemeService.ts
@@ -15,7 +15,7 @@ module SupportCenter {
 
 
         getTheme(): string {
-            if (this.$state.current.name.indexOf('home3') >= 0) {
+            if (this.$state.current.name.indexOf('appServiceEnvironment') >= 0) {
                 return 'default3';
             }
             else {

--- a/AppLensV2/app/DowntimeTimeline/DowntimeTimelineDirective.ts
+++ b/AppLensV2/app/DowntimeTimeline/DowntimeTimelineDirective.ts
@@ -13,18 +13,17 @@ module SupportCenter {
     }
 
     export class DowntimeTimelineCtrl implements IDowntimeTimelineCtrl {
-        public static $inject: string[] = ["SiaService", "SiteService", "$stateParams", "$state"];
+        public static $inject: string[] = ["SiaService", "ResourceServiceFactory", "$stateParams", "$state"];
         public loading: boolean = true;
         public singleabnormaltimeperiod: AbnormalTimePeriod;
         public allTimePeriods: any[] = [];
         public SiaResponse: SiaResponse;
         public selectedDowntime: any;
 
-        constructor(private SiaService: ISiaService, private SiteService: IResourceService, private $stateParams: IStateParams, private $state: angular.ui.IStateService) {
+        constructor(private SiaService: ISiaService, private ResourceServiceFactory: ResourceServiceFactory, private $stateParams: IStateParams, private $state: angular.ui.IStateService) {
             var self = this;
-            this.SiteService.promise.then(function (data: any) {
-                var site = self.SiteService.site;
-
+            let resourceService = ResourceServiceFactory.GetResourceService();
+            resourceService.promise.then(function (data: any) {
                 SiaService.getSiaResponse().then(function (data: IAnalysisResult) {
                     self.SiaResponse = data.Response;
                     self.selectedDowntime = data.SelectedAbnormalTimePeriod

--- a/AppLensV2/app/Home/HomeCtrl.ts
+++ b/AppLensV2/app/Home/HomeCtrl.ts
@@ -32,7 +32,7 @@ module SupportCenter {
             }
             else if (resourceType === 'ase') {
                 this.$stateParams.hostingEnvironmentName = this.aseName;
-                this.$state.go('home3', this.$stateParams);
+                this.$state.go('appServiceEnvironment', this.$stateParams);
             }
         }
     }

--- a/AppLensV2/app/Sia/AnalysisResponse/AnalysisResponseFactory.ts
+++ b/AppLensV2/app/Sia/AnalysisResponse/AnalysisResponseFactory.ts
@@ -1,0 +1,23 @@
+﻿module SupportCenter {
+    export class AnalysisResponseFactory {
+        public static $inject: string[] = ["$stateParams", "$http", "TimeParamsService", "AseService", "SiteService", "$q"]
+        constructor(private $stateParams: IStateParams, private $http: ng.IHttpService, private TimeParamsService: ITimeParamsService, private AseService: IResourceService, private SiteService: IResourceService, private $q: ng.IQService) {
+        }
+
+        GetAnalysis(): IAnalysisResponse {
+            let analysis;
+            switch (this.$stateParams.analysisType) {
+                case Constants.appAnalysis:
+                    analysis = new AppAnalysisResponse(this.$stateParams, this.$http, this.TimeParamsService, this.SiteService, this.$q);
+                    break;
+                case Constants.perfAnalysis:
+                    analysis = new PerfAnalysisResponse(this.$stateParams, this.$http, this.TimeParamsService, this.SiteService, this.$q);
+                    break;
+                case Constants.aseAvailabilityAnalysis:
+                    analysis = new AseAvailabilityAnalysisResponse(this.$stateParams, this.$http, this.TimeParamsService, this.AseService, this.$q);
+                    break;
+            }
+            return analysis;
+        }
+    }
+}

--- a/AppLensV2/app/Sia/AnalysisResponse/AppAnalysisResponse.ts
+++ b/AppLensV2/app/Sia/AnalysisResponse/AppAnalysisResponse.ts
@@ -1,0 +1,42 @@
+﻿module SupportCenter {
+    export class AppAnalysisResponse implements IAnalysisResponse {
+        public static $inject: string[] = ["$stateParams", "$http", "TimeParamsService", "SiteService", "$q"]
+
+        constructor(private $stateParams: IStateParams, private $http: ng.IHttpService, private TimeParamsService: ITimeParamsService, private SiteService: IResourceService, private $q: ng.IQService) {
+        }
+
+        getAnalysisResponse(): ng.IPromise<IAnalysisResult> {
+            var self = this;
+            var deferred = this.$q.defer<IAnalysisResult>();
+
+            let analysis = { Promise: null, Response: null, SelectedAbnormalTimePeriod: null };
+            analysis.Promise = this.$http({
+                method: "GET",
+                url: UriPaths.DiagnosticsPassThroughAPIPath(),
+                headers: {
+                    'GeoRegionApiRoute': UriPaths.AppAnalysisPath(this.SiteService.site, this.TimeParamsService.StartTime, this.TimeParamsService.EndTime, this.TimeParamsService.TimeGrain),
+                    'IsInternal': this.TimeParamsService.IsInternal
+                }
+            }).success((data: any) => {
+
+
+                if (angular.isDefined(data.Properties)) {
+                    analysis.Response = data.Properties;
+                    analysis.SelectedAbnormalTimePeriod = {};
+                    analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
+                    analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
+
+                    deferred.resolve(analysis);
+                }
+                else {
+                    deferred.reject(new ErrorModel(0, "Invalid Data from appanalysis API"));
+                }
+            })
+                .error((data: any) => {
+                    deferred.reject(new ErrorModel(0, "Error calling appanalysis API"));
+                });
+
+            return deferred.promise;
+        }
+    }
+}

--- a/AppLensV2/app/Sia/AnalysisResponse/AseAvailabilityAnalysisResponse.ts
+++ b/AppLensV2/app/Sia/AnalysisResponse/AseAvailabilityAnalysisResponse.ts
@@ -1,0 +1,42 @@
+﻿module SupportCenter {
+    export class AseAvailabilityAnalysisResponse implements IAnalysisResponse {
+        public static $inject: string[] = ["$stateParams", "$http", "TimeParamsService", "AseService", "$q"]
+
+        constructor(private $stateParams: IStateParams, private $http: ng.IHttpService, private TimeParamsService: ITimeParamsService, private AseService: IResourceService, private $q: ng.IQService) {
+        }
+
+        getAnalysisResponse(): ng.IPromise<IAnalysisResult> {
+            var self = this;
+            var deferred = this.$q.defer<IAnalysisResult>();
+
+            let analysis = { Promise: null, Response: null, SelectedAbnormalTimePeriod: null };
+            analysis.Promise = this.$http({
+                method: "GET",
+                url: UriPaths.DiagnosticsPassThroughAPIPath(),
+                headers: {
+                    'GeoRegionApiRoute': UriPaths.AseAvailabilityAnalysisPath(this.AseService.resource, this.TimeParamsService.StartTime, this.TimeParamsService.EndTime, this.TimeParamsService.TimeGrain),
+                    'IsInternal': this.TimeParamsService.IsInternal
+                }
+            }).success((data: any) => {
+
+
+                if (angular.isDefined(data.Properties)) {
+                    analysis.Response = data.Properties;
+                    analysis.SelectedAbnormalTimePeriod = {};
+                    analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
+                    analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
+
+                    deferred.resolve(analysis);
+                }
+                else {
+                    deferred.reject(new ErrorModel(0, "Invalid Data from aseAvailabilityAnalysis API"));
+                }
+            })
+                .error((data: any) => {
+                    deferred.reject(new ErrorModel(0, "Error in call to aseAvailabilityAnalysis API"));
+                });
+
+            return deferred.promise;
+        }
+    }
+}

--- a/AppLensV2/app/Sia/AnalysisResponse/IAnalysisResponse.ts
+++ b/AppLensV2/app/Sia/AnalysisResponse/IAnalysisResponse.ts
@@ -1,0 +1,7 @@
+﻿module SupportCenter {
+    "use strict";
+
+    export interface IAnalysisResponse {
+        getAnalysisResponse(): ng.IPromise<IAnalysisResult>;
+    }
+}

--- a/AppLensV2/app/Sia/AnalysisResponse/PerfAnalysisResponse.ts
+++ b/AppLensV2/app/Sia/AnalysisResponse/PerfAnalysisResponse.ts
@@ -1,0 +1,42 @@
+﻿module SupportCenter {
+    export class PerfAnalysisResponse implements IAnalysisResponse {
+        public static $inject: string[] = ["$stateParams", "$http", "TimeParamsService", "SiteService", "$q"]
+
+        constructor(private $stateParams: IStateParams, private $http: ng.IHttpService, private TimeParamsService: ITimeParamsService, private SiteService: IResourceService, private $q: ng.IQService) {
+        }
+
+        getAnalysisResponse(): ng.IPromise<IAnalysisResult> {
+            var self = this;
+            var deferred = this.$q.defer<IAnalysisResult>();
+
+            let analysis = { Promise: null, Response: null, SelectedAbnormalTimePeriod: null };
+            analysis.Promise = this.$http({
+                method: "GET",
+                url: UriPaths.DiagnosticsPassThroughAPIPath(),
+                headers: {
+                    'GeoRegionApiRoute': UriPaths.PerfAnalysisPath(this.SiteService.site, this.TimeParamsService.StartTime, this.TimeParamsService.EndTime, this.TimeParamsService.TimeGrain),
+                    'IsInternal': this.TimeParamsService.IsInternal
+                }
+            }).success((data: any) => {
+
+
+                if (angular.isDefined(data.Properties)) {
+                    analysis.Response = data.Properties;
+                    analysis.SelectedAbnormalTimePeriod = {};
+                    analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
+                    analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
+
+                    deferred.resolve(analysis);
+                }
+                else {
+                    deferred.reject(new ErrorModel(0, "Invalid Data from perfanalysis API"));
+                    }
+                })
+                .error((data: any) => {
+                    deferred.reject(new ErrorModel(0, "Error in call to perfanalysis API"));
+                });
+
+            return deferred.promise;
+        }
+    }
+}

--- a/AppLensV2/app/Sia/SiaCtrl.ts
+++ b/AppLensV2/app/Sia/SiaCtrl.ts
@@ -5,9 +5,9 @@ module SupportCenter {
 
     export class SiaCtrl {
 
-        public static $inject: string[] = ["SiaService", "SiteService", "$window", "ErrorHandlerService", "ThemeService", "$stateParams"];
+        public static $inject: string[] = ["SiaService", "$window", "ErrorHandlerService", "ThemeService", "$stateParams", "ResourceServiceFactory"];
         
-        constructor(private SiaService: ISiaService, private SiteService: IResourceService, private $window: angular.IWindowService, private ErrorHandlerService: IErrorHandlerService, private ThemeService: IThemeService, private $stateParams: IStateParams) {
+        constructor(private SiaService: ISiaService, private $window: angular.IWindowService, private ErrorHandlerService: IErrorHandlerService, private ThemeService: IThemeService, private $stateParams: IStateParams, private ResourceServiceFactory: ResourceServiceFactory) {
 
             var self = this;
             this.DetectorData = {};
@@ -18,7 +18,8 @@ module SupportCenter {
                 this.isVNext = false;
             }
 
-            this.SiteService.promise.then(function (data: any) {
+            let service = ResourceServiceFactory.GetResourceService();
+            service.promise.then(function (data: any) {
 
                 self.SiaService.getSiaResponse().then(function (data: IAnalysisResult) {
                     self.SiaResponse = data.Response;

--- a/AppLensV2/app/app.ts
+++ b/AppLensV2/app/app.ts
@@ -12,6 +12,7 @@ module SupportCenter {
         .service("FeedbackService", FeedbackService)
         .service("ErrorHandlerService", ErrorHandlerService)
         .service("AseService", AseService)
+        .service("AnalysisResponseFactory", AnalysisResponseFactory)
         .service("ThemeService", ThemeService)
         .controller("HomeCtrl",HomeCtrl)
         .controller("MainCtrl", MainCtrl)

--- a/AppLensV2/app/app.ts
+++ b/AppLensV2/app/app.ts
@@ -180,13 +180,16 @@ module SupportCenter {
                         }
                     }
                 })
-                .state('home3.aseAvailabilityAnalysis.sia', {
+                .state('home3.sia', {
                     views: {
                         'childContent': {
                             templateUrl: 'app/Sia/sia.html',
                             controller: 'SiaCtrl',
                             controllerAs: 'sia'
                         }
+                    },
+                    params: {
+                        analysisType: 'aseAvailabilityAnalysis'
                     }
                 })
                 .state('sites.appanalysis.detector', {

--- a/AppLensV2/app/app.ts
+++ b/AppLensV2/app/app.ts
@@ -80,7 +80,7 @@ module SupportCenter {
                     controller: 'MainCtrl',
                     controllerAs: 'main'
                 })
-                .state('home3', {
+                .state('appServiceEnvironment', {
                     url: '/hostingEnvironments/{hostingEnvironmentName}?{startTime}&{endTime}&{timeGrain}&{isInternal}&{vNext}',
                     templateUrl: 'app/AppServiceEnvironment/appServiceEnvironment.html',
                     controller: 'AppServiceEnvironmentCtrl',
@@ -138,7 +138,7 @@ module SupportCenter {
                         analysisType: 'perfAnalysis'
                     }
                 })
-                .state('home3.aseAvailabilityAnalysis', {
+                .state('appServiceEnvironment.aseAvailabilityAnalysis', {
                     url: '/aseAvailabilityAnalysis',
                     views: {
                         'childContent': {
@@ -200,7 +200,7 @@ module SupportCenter {
                         }
                     }
                 })
-                .state('home3.detector', {
+                .state('appServiceEnvironment.detector', {
                     url: '/detectors/{detectorName}',
                     views: {
                         'childContent': {

--- a/AppLensV2/app/app.ts
+++ b/AppLensV2/app/app.ts
@@ -141,10 +141,10 @@ module SupportCenter {
                 .state('home3.aseAvailabilityAnalysis', {
                     url: '/aseAvailabilityAnalysis',
                     views: {
-                        'mainContent': {
-                            templateUrl: 'app/AppServiceEnvironment/appServiceEnvironment.html',
-                            controller: 'AppServiceEnvironmentCtrl',
-                            controllerAs: 'ase'
+                        'childContent': {
+                            templateUrl: 'app/Sia/sia.html',
+                            controller: 'SiaCtrl',
+                            controllerAs: 'sia'
                         }
                     },
                     params: {
@@ -178,18 +178,6 @@ module SupportCenter {
                             controller: 'SiaCtrl',
                             controllerAs: 'sia'
                         }
-                    }
-                })
-                .state('home3.sia', {
-                    views: {
-                        'childContent': {
-                            templateUrl: 'app/Sia/sia.html',
-                            controller: 'SiaCtrl',
-                            controllerAs: 'sia'
-                        }
-                    },
-                    params: {
-                        analysisType: 'aseAvailabilityAnalysis'
                     }
                 })
                 .state('sites.appanalysis.detector', {

--- a/AppLensV2/app/app.ts
+++ b/AppLensV2/app/app.ts
@@ -13,6 +13,7 @@ module SupportCenter {
         .service("ErrorHandlerService", ErrorHandlerService)
         .service("AseService", AseService)
         .service("AnalysisResponseFactory", AnalysisResponseFactory)
+        .service("ResourceServiceFactory", ResourceServiceFactory)
         .service("ThemeService", ThemeService)
         .controller("HomeCtrl",HomeCtrl)
         .controller("MainCtrl", MainCtrl)
@@ -137,6 +138,19 @@ module SupportCenter {
                         analysisType: 'perfAnalysis'
                     }
                 })
+                .state('home3.aseAvailabilityAnalysis', {
+                    url: '/aseAvailabilityAnalysis',
+                    views: {
+                        'mainContent': {
+                            templateUrl: 'app/AppServiceEnvironment/appServiceEnvironment.html',
+                            controller: 'AppServiceEnvironmentCtrl',
+                            controllerAs: 'ase'
+                        }
+                    },
+                    params: {
+                        analysisType: 'aseAvailabilityAnalysis'
+                    }
+                })
                 // Old state - just exists to redirect to [sites/stampsites].appanalysis.detector
                 .state('sites.detector', {
                     url: '/detectors/{detectorName}',
@@ -166,8 +180,7 @@ module SupportCenter {
                         }
                     }
                 })
-                .state('home3.sia', {
-                    url: '/appanalysis',
+                .state('home3.aseAvailabilityAnalysis.sia', {
                     views: {
                         'childContent': {
                             templateUrl: 'app/Sia/sia.html',


### PR DESCRIPTION
- Show correlated detectors to downtimes detected by runtime availability detector
- Adjust routes to reflect aseAvailabilityAnalysis and to run Sia
- Abstract the different type of resource results from the Sia module 
- Abstract the AseService and the SiteService from SiaCtrl, DowntimeTimelineCtrl

![image](https://cloud.githubusercontent.com/assets/917998/26516233/bf98912c-4237-11e7-871d-279adae82b5d.png)
