### PR TITLE
Update Clients to handle both V1 and V2 API responses

### DIFF
--- a/AppLensV2/app/Common/DetectorsService.ts
+++ b/AppLensV2/app/Common/DetectorsService.ts
@@ -57,9 +57,9 @@ module SupportCenter {
             })
                 .success((data: any) => {
 
-                    if (angular.isDefined(data)) {
+                    if (angular.isDefined(data) && angular.isDefined(data.Value)) {
 
-                        _.each(data, function (item: any) {
+                        _.each(data.Value, function (item: any) {
 
                             if (angular.isDefined(item.Properties)) {
 

--- a/AppLensV2/app/Common/DetectorsService.ts
+++ b/AppLensV2/app/Common/DetectorsService.ts
@@ -57,6 +57,7 @@ module SupportCenter {
             })
                 .success((data: any) => {
 
+
                     if (angular.isDefined(data) && angular.isDefined(data.Value)) {
 
                         _.each(data.Value, function (item: any) {
@@ -73,24 +74,29 @@ module SupportCenter {
                                 detectors.push(detector);
                             }
                             else {
-                                var detector = new DetectorDefinition(
-                                    item.Name,
-                                    item.DisplayName,
-                                    item.Description,
-                                    item.Rank,
-                                    item.IsEnabled, -1);
-
-                                detectors.push(detector);
+                                
                             }
                         });
+                    }
+                    else if (angular.isDefined(data)) {
+                        _.each(data, function (item: any) {
+                            var detector = new DetectorDefinition(
+                                item.Name,
+                                item.DisplayName,
+                                item.Description,
+                                item.Rank,
+                                item.IsEnabled, -1);
 
-                        self.detectorsListCache["detectorList"] = detectors;
-                        self.detectorsList = detectors;
-                        deferred.resolve(self.detectorsList);
+                            detectors.push(detector);
+                        });
                     }
                     else {
-                        deferred.reject(new ErrorModel(0, "Value field not present in Get Detectors Api response"));
+                        deferred.reject(new ErrorModel(0, "Invalid Get Detectors Api response"));
                     }
+
+                    self.detectorsListCache["detectorList"] = detectors;
+                    self.detectorsList = detectors;
+                    deferred.resolve(self.detectorsList);
                 })
                 .error((err: any) => {
                     deferred.reject(ErrorModelBuilder.Build(err));

--- a/AppLensV2/app/Common/DetectorsService.ts
+++ b/AppLensV2/app/Common/DetectorsService.ts
@@ -57,9 +57,9 @@ module SupportCenter {
             })
                 .success((data: any) => {
 
-                    if (angular.isDefined(data.Value)) {
+                    if (angular.isDefined(data)) {
 
-                        _.each(data.Value, function (item: any) {
+                        _.each(data, function (item: any) {
 
                             if (angular.isDefined(item.Properties)) {
 
@@ -69,6 +69,16 @@ module SupportCenter {
                                     item.Properties.Description,
                                     item.Properties.Rank,
                                     item.Properties.IsEnabled, -1);
+
+                                detectors.push(detector);
+                            }
+                            else {
+                                var detector = new DetectorDefinition(
+                                    item.Name,
+                                    item.DisplayName,
+                                    item.Description,
+                                    item.Rank,
+                                    item.IsEnabled, -1);
 
                                 detectors.push(detector);
                             }
@@ -119,8 +129,8 @@ module SupportCenter {
 
                     var response = new DetectorResponse(this.TimeParamsService.StartTime, this.TimeParamsService.EndTime, [], [], null);
 
-                    if (angular.isDefined(data.Properties)) {
-                        response = data.Properties;
+                    if (angular.isDefined(data)) {
+                        response = angular.isDefined(data.Properties) ? data.Properties : data;
                         deferred.resolve(response);
 
                         var timeDifferenceInMinutes = 24 * 60;

--- a/AppLensV2/app/Common/SiteService.ts
+++ b/AppLensV2/app/Common/SiteService.ts
@@ -42,6 +42,15 @@ module SupportCenter {
                                     self.site.numberOfTriggeredWebJobs = data.Properties.TriggeredWebJobsCount;
                                     self.site.sku = data.Properties.Sku;
                                 }
+                                else {
+                                    self.site.stack = data.AppStack;
+                                    self.site.kind = data.Kind === 'app' || data.Kind === null ? 'webapp' : data.Kind;
+                                    self.site.isLinux = data.IsLinux;
+                                    self.site.numberOfSlots = data.NumberOfSlots;
+                                    self.site.numberOfContinousWebJobs = data.ContinuousWebJobsCount;
+                                    self.site.numberOfTriggeredWebJobs = data.TriggeredWebJobsCount;
+                                    self.site.sku = data.Sku;
+                                }
                             });
                     })
                     .error(function (err: any) {

--- a/AppLensV2/app/Sia/AnalysisResponse/AppAnalysisResponse.ts
+++ b/AppLensV2/app/Sia/AnalysisResponse/AppAnalysisResponse.ts
@@ -18,19 +18,13 @@
                     'IsInternal': this.TimeParamsService.IsInternal
                 }
             }).success((data: any) => {
+                analysis.Response = angular.isDefined(data.Properties) ? data.Properties: data;
 
+                analysis.SelectedAbnormalTimePeriod = {};
+                analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
+                analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
 
-                if (angular.isDefined(data.Properties)) {
-                    analysis.Response = data.Properties;
-                    analysis.SelectedAbnormalTimePeriod = {};
-                    analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
-                    analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
-
-                    deferred.resolve(analysis);
-                }
-                else {
-                    deferred.reject(new ErrorModel(0, "Invalid Data from appanalysis API"));
-                }
+                deferred.resolve(analysis);
             })
                 .error((data: any) => {
                     deferred.reject(new ErrorModel(0, "Error calling appanalysis API"));

--- a/AppLensV2/app/Sia/AnalysisResponse/AseAvailabilityAnalysisResponse.ts
+++ b/AppLensV2/app/Sia/AnalysisResponse/AseAvailabilityAnalysisResponse.ts
@@ -18,19 +18,12 @@
                     'IsInternal': this.TimeParamsService.IsInternal
                 }
             }).success((data: any) => {
+                analysis.Response = angular.isDefined(data.Properties) ? data.Properties: data;
+                analysis.SelectedAbnormalTimePeriod = {};
+                analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
+                analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
 
-
-                if (angular.isDefined(data.Properties)) {
-                    analysis.Response = data.Properties;
-                    analysis.SelectedAbnormalTimePeriod = {};
-                    analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
-                    analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
-
-                    deferred.resolve(analysis);
-                }
-                else {
-                    deferred.reject(new ErrorModel(0, "Invalid Data from aseAvailabilityAnalysis API"));
-                }
+                deferred.resolve(analysis);
             })
                 .error((data: any) => {
                     deferred.reject(new ErrorModel(0, "Error in call to aseAvailabilityAnalysis API"));

--- a/AppLensV2/app/Sia/AnalysisResponse/PerfAnalysisResponse.ts
+++ b/AppLensV2/app/Sia/AnalysisResponse/PerfAnalysisResponse.ts
@@ -20,21 +20,17 @@
             }).success((data: any) => {
 
 
-                if (angular.isDefined(data.Properties)) {
-                    analysis.Response = data.Properties;
-                    analysis.SelectedAbnormalTimePeriod = {};
-                    analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
-                    analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
+                analysis.Response = angular.isDefined(data.Properties) ? data.Properties: data;
+                analysis.SelectedAbnormalTimePeriod = {};
+                analysis.SelectedAbnormalTimePeriod.index = analysis.Response.AbnormalTimePeriods.length - 1;
+                analysis.SelectedAbnormalTimePeriod.data = analysis.Response.AbnormalTimePeriods[analysis.SelectedAbnormalTimePeriod.index];
 
-                    deferred.resolve(analysis);
-                }
-                else {
-                    deferred.reject(new ErrorModel(0, "Invalid Data from perfanalysis API"));
-                    }
-                })
-                .error((data: any) => {
-                    deferred.reject(new ErrorModel(0, "Error in call to perfanalysis API"));
-                });
+                deferred.resolve(analysis);
+
+            })
+            .error((data: any) => {
+                deferred.reject(new ErrorModel(0, "Error in call to perfanalysis API"));
+            });
 
             return deferred.promise;
         }


### PR DESCRIPTION
The difference is that V1 uses envelopes, which is a CSM signature, and V2 does not for reasons of making the client change in the geomaster work. This change will allow for the applens georegion clients to handle either return type. 