### PR TITLE
Add reboot stuck detector

### DIFF
--- a/AppLensV2/app/Common/SiaService.ts
+++ b/AppLensV2/app/Common/SiaService.ts
@@ -65,9 +65,11 @@ module SupportCenter {
                 DetectorData[detectorAnalysisData.Source].chartoptions = detectorViewHelper.GetChartOptions(detectorAnalysisData.Source);
                 DetectorData[detectorAnalysisData.Source].chartdata = detectorViewHelper.GetChartData(siaResponse.StartTime, siaResponse.EndTime, detectorAnalysisData.Metrics, detectorAnalysisData.Source);
 
-                DetectorData[detectorAnalysisData.Source].chartoptions.chart.height =
-                    DetectorData[detectorAnalysisData.Source].chartoptions.chart.height + (DetectorData[detectorAnalysisData.Source].chartdata.length / 8) * 20;
-                DetectorData[detectorAnalysisData.Source].chartoptions.chart.margin.top = 20 + (DetectorData[detectorAnalysisData.Source].chartdata.length / 8) * 20;
+                if (detectorAnalysisData.Source !== 'rebootrolesstuck') {
+                    DetectorData[detectorAnalysisData.Source].chartoptions.chart.height =
+                        DetectorData[detectorAnalysisData.Source].chartoptions.chart.height + (DetectorData[detectorAnalysisData.Source].chartdata.length / 8) * 20;
+                    DetectorData[detectorAnalysisData.Source].chartoptions.chart.margin.top = 20 + (DetectorData[detectorAnalysisData.Source].chartdata.length / 8) * 20;
+                }
 
                 DetectorData[detectorAnalysisData.Source].responsemetadata = detectorAnalysisData.DetectorMetaData;
                 DetectorData[detectorAnalysisData.Source].info = detectorAnalysisData.DetectorDefinition;

--- a/AppLensV2/app/Detector/DetectorViewHelper.ts
+++ b/AppLensV2/app/Detector/DetectorViewHelper.ts
@@ -151,7 +151,7 @@ module SupportCenter {
             
             var chartData = [];
 
-            if (!self.IsNv3ChartEnabled(detectorName)) {
+            if (!self.IsNvd3ChartEnabled(detectorName)) {
                 return self.GetGoogleChartData(startTimeStr, endTimeStr, metrics, detectorName);
             }
 
@@ -281,14 +281,14 @@ module SupportCenter {
 
             chartObject.options = {
                 'title': 'Upgrade Domain',
-                'width': 1400,
+                'width': this.$window.innerWidth * 0.75,
                 'height': this.graphHeight * 2
             };
 
             return chartObject;
         }
 
-        public IsNv3ChartEnabled(detectorName: string): boolean {
+        public IsNvd3ChartEnabled(detectorName: string): boolean {
             let isNv3ChartEnabled: boolean = false;
             switch (detectorName) {
                 case 'rebootrolesstuck':

--- a/AppLensV2/app/Detector/DetectorViewHelper.ts
+++ b/AppLensV2/app/Detector/DetectorViewHelper.ts
@@ -267,14 +267,14 @@ module SupportCenter {
             var chartObjectRows = [];
 
             for (let metric of metrics) {
-                chartObjectRows.push({ c: [{ v: metric.Name.substring(metric.Name.lastIndexOf("-") + 1) }, { v: new Date(metric.StartTime) }, { v: new Date(metric.EndTime) }] });
+                chartObjectRows.push({ c: [{ v: metric.Name.substring(metric.Name.lastIndexOf("-") + 1) }, { v: new Date(metric.StartTime.replace("Z", "")) }, { v: new Date(metric.EndTime.replace("Z", "")) }] });
             }
 
             chartObject.data = {
                 "cols": [
                     { label: "UpgradeDomain", type: "string" },
-                    { label: "Start", type: "date" },
-                    { label: "End", type: "date" }
+                    { label: "Start", type: "datetime" },
+                    { label: "End", type: "datetime" }
                 ],
                 "rows": chartObjectRows
             };

--- a/AppLensV2/app/Detector/DetectorViewHelper.ts
+++ b/AppLensV2/app/Detector/DetectorViewHelper.ts
@@ -151,6 +151,10 @@ module SupportCenter {
             
             var chartData = [];
 
+            if (!self.IsNv3ChartEnabled(detectorName)) {
+                return self.GetGoogleChartData(startTimeStr, endTimeStr, metrics, detectorName);
+            }
+
             var fileStorageTitle = [];
             
             var startTime = new Date(startTimeStr);
@@ -255,6 +259,47 @@ module SupportCenter {
             }
 
             return chartData;
+        }
+
+        public GetGoogleChartData(startTimeStr: string, endTimeStr: string, metrics: DiagnosticMetricSet[], detectorName: string = ''): any {
+            var chartObject: any = {};
+            chartObject.type = "Timeline";
+            var chartObjectRows = [];
+
+            for (let metric of metrics) {
+                chartObjectRows.push({ c: [{ v: metric.Name.substring(metric.Name.lastIndexOf("-") + 1) }, { v: new Date(metric.StartTime) }, { v: new Date(metric.EndTime) }] });
+            }
+
+            chartObject.data = {
+                "cols": [
+                    { label: "UpgradeDomain", type: "string" },
+                    { label: "Start", type: "date" },
+                    { label: "End", type: "date" }
+                ],
+                "rows": chartObjectRows
+            };
+
+            chartObject.options = {
+                'title': 'Upgrade Domain',
+                'width': 1400,
+                'height': this.graphHeight * 2
+            };
+
+            return chartObject;
+        }
+
+        public IsNv3ChartEnabled(detectorName: string): boolean {
+            let isNv3ChartEnabled: boolean = false;
+            switch (detectorName) {
+                case 'rebootrolesstuck':
+                    isNv3ChartEnabled = false;
+                    break;
+                default:
+                    isNv3ChartEnabled = true;
+                    break;
+            }
+
+            return isNv3ChartEnabled;
         }
 
         public GetDetailedChartData(metrics: DiagnosticMetricSet[], detectorName: string = ''): DetailedGraphData {

--- a/AppLensV2/app/Detector/detectorview.html
+++ b/AppLensV2/app/Detector/detectorview.html
@@ -42,7 +42,8 @@
                         <!--<div flex ng-if="detectorviewctrl.isLoading" ng-style="{'height':detectorviewctrl.chartOptions.chart.height}">
                          </div>-->
                         <nvd3 options="detectorviewctrl.chartoptions" data="detectorviewctrl.chartdata"
-                                  ng-if="!detectorviewctrl.isLoading && detectorviewctrl.info.Name !== 'instanceallocations'" api="detectorviewctrl.api"></nvd3>
+                                  ng-if="!detectorviewctrl.isLoading && detectorviewctrl.info.Name !== 'instanceallocations' && detectorviewctrl.info.Name !== 'rebootrolesstuck'" api="detectorviewctrl.api"></nvd3>
+                        <div google-chart chart="detectorviewctrl.chartdata" ng-if="!detectorviewctrl.isLoading && detectorviewctrl.info.Name === 'rebootrolesstuck'"></div>
                         <detailed-detector-view loading="detectorviewctrl.loading" metricsets="detectorviewctrl.metricsets" selectedworker="detectorviewctrl.selectedworker" detectorsource="detectorviewctrl.detectorsource"
                                                 ng-if="(detectorviewctrl.info.Name.indexOf('cpuanalysis') >= 0 || detectorviewctrl.info.Name.indexOf('memoryanalysis') >= 0) && detectorviewctrl.showDetailedView"></detailed-detector-view>
                         <md-button ng-click="detectorviewctrl.showDetailedView = !detectorviewctrl.showDetailedView" ng-if="detectorviewctrl.info.Name.indexOf('cpuanalysis') >= 0 || detectorviewctrl.info.Name.indexOf('memoryanalysis') >= 0"/>
@@ -168,6 +169,8 @@
 
                 </md-tab>
             </md-tabs>
+
+
 
         </div>
     </div>

--- a/AppLensV2/app/app.ts
+++ b/AppLensV2/app/app.ts
@@ -3,7 +3,7 @@
 module SupportCenter {
     "use strict";
 
-    var app = angular.module("supportCenterApp", ["ngMaterial", "ngMdIcons", "ngLetterAvatar", "ui.router", "nvd3", "ngSanitize", "btford.markdown", "jlareau.bowser", "md.data.table"])
+    var app = angular.module("supportCenterApp", ["ngMaterial", "ngMdIcons", "ngLetterAvatar", "ui.router", "nvd3", "ngSanitize", "btford.markdown", "jlareau.bowser", "md.data.table", "googlechart"])
 
         .service("DetectorsService", DetectorsService)
         .service("SiaService", SiaService)

--- a/AppLensV2/bower.json
+++ b/AppLensV2/bower.json
@@ -25,6 +25,7 @@
     "angular-markdown-directive": "^0.3.1",
     "angular-material-data-table": "^0.10.10",
     "angular-bowser": "^0.0.4",
-    "animate.css": "^3.5.2"
+    "animate.css": "^3.5.2",
+    "angular-google-chart": "^0.1.0"
   }
 }

--- a/AppLensV2/index.html
+++ b/AppLensV2/index.html
@@ -29,6 +29,7 @@
     <script src="bower_components/showdown/compressed/Showdown.js"></script>
     <script src="bower_components/angular-markdown-directive/markdown.js"></script>
     <script src="bower_components/angular-bowser/src/angular-bowser.js"></script>
+    <script src="bower_components/angular-google-chart/ng-google-chart.js"></script>
     <script type="text/javascript" src="bower_components/angular-material-data-table/dist/md-data-table.min.js"></script>
 
     <script src="app/app.js"></script>


### PR DESCRIPTION
This is using the [google charts library](https://developers.google.com/chart/) to create a timeline chart for RebootAllRolesStuck detector. 

It attempts to give an idea on how long each UD has been taking in the deployment and suggests when a UD is taking too long further suggesting a stuck deployment.

![image](https://user-images.githubusercontent.com/917998/28990308-076b3f92-7931-11e7-8cb0-779439ba505a.png)
