### PR TITLE
Fixing DetailedGraphEnabledDetectors logic for TcpConnections Detectors

### DIFF
--- a/AppLensV2/app/Detector/DetectorViewHelper.ts
+++ b/AppLensV2/app/Detector/DetectorViewHelper.ts
@@ -187,7 +187,7 @@ module SupportCenter {
 
                 var skipMetric = false;
                 for (var i = 0; i < DetectorViewHelper.DetailedGraphEnabledDetectors.length; i++) {
-                    if (detectorName.indexOf(DetectorViewHelper.DetailedGraphEnabledDetectors[i].name) > 0 && metric.Name !== DetectorViewHelper.DetailedGraphEnabledDetectors[i].metric) {
+                    if (detectorName.indexOf(DetectorViewHelper.DetailedGraphEnabledDetectors[i].name) >= 0 && metric.Name !== DetectorViewHelper.DetailedGraphEnabledDetectors[i].metric) {
                         skipMetric = true;
                         break;
                     }


### PR DESCRIPTION
This issue was causing all the metrics for TcpConnections Detector to get displayed. For the other entries in DetailedGraphEnabledDetectors, the logic was working because they were preceded by the word 'site' in front of them. Correcting the line to check for >=0 is enough to fix the problem.

