### PR TITLE
Remove max height so as to allow lengthy responses from detectors

### DIFF
--- a/AppLensV2/app/Detector/detectorview.html
+++ b/AppLensV2/app/Detector/detectorview.html
@@ -174,7 +174,7 @@
                 </md-tab>
             </md-tabs>
 
-            <div layout="column" flex="95" style="margin:10px;padding:5px;max-width:60%;border-radius:15px;border-bottom-left-radius:0" ng-if="detectorviewctrl.abnormaltimeperiods !== undefined">
+            <div layout="column" flex="95" style="margin:10px;padding:5px;max-width:60%;border-radius:15px;border-bottom-left-radius:0; max-height:none" ng-if="detectorviewctrl.abnormaltimeperiods !== undefined">
                 <h3 style="text-decoration:underline">Observations:</h3>
                 <div ng-if="detectorviewctrl.areObservationsProvided() === true">
                     <div ng-if="detectorviewctrl.areSameObservations() === true">
@@ -193,7 +193,7 @@
                     No Observations Provided. (Please report using feedback button at top)
                 </div>
             </div>
-            <div layout="column" flex="95" style="margin:10px;padding:5px;max-width:60%;border-radius:15px;border-bottom-left-radius:0" ng-if="detectorviewctrl.abnormaltimeperiods !== undefined">
+            <div layout="column" flex="95" style="margin:10px;padding:5px;max-width:60%;border-radius:15px;border-bottom-left-radius:0; max-height:none" ng-if="detectorviewctrl.abnormaltimeperiods !== undefined">
                 <h3 style="text-decoration:underline">Solutions:</h3>
                 <div ng-if="detectorviewctrl.isSameSolution() === true">
                     {{::detectorviewctrl.singleSolutionMessage}}


### PR DESCRIPTION
Text for observations and solutions sometimes overlap when observations pass the max height set by the angular flex class.

To fix the problem, just add inline CSS to remove max height property

**With max-height : 100%**
![image](https://user-images.githubusercontent.com/917998/32012584-2d3c892a-b96d-11e7-8bd4-15f5d0c93411.png)

**With max-height:None**
![image](https://user-images.githubusercontent.com/917998/32012603-3e67955a-b96d-11e7-9133-dbf3f689d73f.png)
