### PR TITLE
Only run AseHealthCheck for sites in ministamp

### DIFF
--- a/AppLensV2/app/Common/Constants.ts
+++ b/AppLensV2/app/Common/Constants.ts
@@ -135,8 +135,14 @@ module SupportCenter {
                 }
 
                 path =
-                    path.replace("{hostnames}", hostNamesFilter)
-                        .replace("{hostingEnvironmentName}", resource.stampName);
+                    path.replace("{hostnames}", hostNamesFilter);
+                //if this site lives in ministamp then resource.stampName will be the ASE friendly name
+                if (resource.stampName.indexOf('waws-prod') < 0) {
+                    path = path.replace("{hostingEnvironmentName}", resource.stampName);
+                } else {
+                    path = path.replace("{hostingEnvironmentName}", '');
+                }
+
             } else {
                 var hostingEnvironment = resource as HostingEnvironment;
                 path =


### PR DESCRIPTION
ASE Health Check is getting correlated for non-ministamp sites 
eg., https://applensv2.azurewebsites.net/sites/refresh/appanalysis/detectors/asehealthcheck?startTime=2017-11-30T00:00:00.000Z&endTime=2017-11-30T23:59:00.000Z

This is an immediate fix for that bug. There is a small change that also needs to happen in our back end but this should be okay for now.