### PR TITLE
Getting Cluster name for stamp + few other fixes

### DIFF
--- a/AppLensV2/Controllers/SitesController.cs
+++ b/AppLensV2/Controllers/SitesController.cs
@@ -48,6 +48,19 @@ namespace AppLensV2
         }
 
         [HttpGet]
+        [Route("api/stamps/{stampName}/cluster")]
+        public async Task<IHttpActionResult> GetStampCluster(string stampName)
+        {
+            var result = await SupportObserverClient.GetStampCluster(stampName);
+            if(result.StatusCode != HttpStatusCode.OK)
+            {
+                return ResponseMessage(Request.CreateErrorResponse(result.StatusCode, (string)result.Content));
+            }
+
+            return Ok(result.Content);
+        }
+
+        [HttpGet]
         [Route("api/hostingEnvironments/{hostingEnvironmentName}")]
         public async Task<IHttpActionResult> GetHostingEnvironmentDetails(string hostingEnvironmentName)
         {

--- a/AppLensV2/Helpers/CaseAnalysisHelper.cs
+++ b/AppLensV2/Helpers/CaseAnalysisHelper.cs
@@ -158,15 +158,23 @@ namespace AppLensV2
 
         public static async Task<string> GetSrIdFromWorkflowId(string workflowId)
         {
-            string query = KustoQueries.GetSrIdFromWorkflowIdQuery(workflowId);
-            var result = await KustoManager.Instance.ExecuteQueryAsync(query, "azsupport", "AzureSupportability");
-
-            if(result != null && result.Rows != null && result.Rows.Count > 0)
+            // Temporary workaround. For more details, See issue https://github.com/ShekharGupta1988/AppLensV2/issues/1016
+            string srId = null;
+            try
             {
-                return result.Rows[0][0].ToString();
+                string query = KustoQueries.GetSrIdFromWorkflowIdQuery(workflowId);
+                var result = await KustoManager.Instance.ExecuteQueryAsync(query, "azsupport", "AzureSupportability");
+
+                if (result != null && result.Rows != null && result.Rows.Count > 0)
+                {
+                    srId = result.Rows[0][0].ToString();
+                }
+            }
+            catch
+            {
             }
 
-            return null;
+            return srId;
         }
 
         private static NameValuePropertyBag ParseDataEntry(string data)

--- a/AppLensV2/app/Analysis/AppRestartAnalysis/AppRestartAnalysisCtrl.ts
+++ b/AppLensV2/app/Analysis/AppRestartAnalysis/AppRestartAnalysisCtrl.ts
@@ -27,7 +27,7 @@ module SupportCenter {
             this.chartOptions.chart.height = this.$window.innerHeight * 0.25;
             this.chartOptions.chart.color = this.seriesColors;
             this.chartOptions.chart.callback = function (chart) {
-                chart.dispatch.changeState({ disabled: { 0: true } });
+                chart.dispatch.changeState({ disabled: { 1: true } });
             }
 
             this.isLoading = true;
@@ -43,7 +43,7 @@ module SupportCenter {
                     else {
 
                         self.chartOptions.chart.callback = function (chart) {
-                            chart.dispatch.changeState({ disabled: { 0: false } })
+                            chart.dispatch.changeState({ disabled: { 1: false } })
                         };
 
                         let workerprocessrecycle = _.find(response.Payload, function (item) {
@@ -213,7 +213,7 @@ module SupportCenter {
         public selectedWorker: string;
         public isLoading: boolean;
         public noReason: any;
-        public seriesColors: [string] = ["#D4E157", "hsl(120, 57%, 40%)", "#117dbb", "#FFA726", "#aa0000", "#311B92", "#4DB6AC", "#880E4F", "#0D47A1", "#00695C"]; 
+        public seriesColors: [string] = ["#d6591b", "hsl(120, 57%, 40%)", "#117dbb", "#FFA726", "#aa0000", "#311B92", "#4DB6AC", "#880E4F", "#0D47A1", "#00695C"]; 
         public siteName;
     }
 }

--- a/AppLensV2/app/Common/AseService.ts
+++ b/AppLensV2/app/Common/AseService.ts
@@ -9,12 +9,13 @@ module SupportCenter {
         hostingEnvironment: HostingEnvironment;
         resource: Resource;
         sites: Array<Site>;
+        GetStampCluster(): ng.IPromise<string>;
     }
 
     export class AseService implements IResourceService {
 
-        static $inject = ['$http', '$stateParams', 'ErrorHandlerService'];
-        constructor(private $http: ng.IHttpService, private $stateParams: IStateParams, private ErrorHandlerService: IErrorHandlerService) {
+        static $inject = ['$http', '$stateParams', 'ErrorHandlerService', '$q'];
+        constructor(private $http: ng.IHttpService, private $stateParams: IStateParams, private ErrorHandlerService: IErrorHandlerService, private $q: ng.IQService) {
             var self = this;
 
             if (!angular.isDefined(this.$stateParams.siteName) || this.$stateParams.siteName === '') {
@@ -44,5 +45,17 @@ module SupportCenter {
         public hostingEnvironment: HostingEnvironment;
         public resource: Resource;
         public sites: Site[];
+
+        public GetStampCluster(): ng.IPromise<string> {
+
+            var deferred = this.$q.defer<string>();
+            let url: string = UriPaths.StampClusterAPIPath(this.hostingEnvironment.resourceInternalStamp);
+            this.$http.get(url)
+                .success((data: any) => {
+                    deferred.resolve(data);
+                });
+
+            return deferred.promise;
+        }
     }
 }

--- a/AppLensV2/app/Common/Constants.ts
+++ b/AppLensV2/app/Common/Constants.ts
@@ -20,6 +20,7 @@ module SupportCenter {
         private static appServiceEnvironmentDetails: string = "/api/hostingEnvironments/{hostingEnvironmentName}"
         private static diagnosticsPassThroughApiPath: string = "/api/diagnostics";
         private static detectorsDocumentAPIPath: string = "/api/detectors/{detectorName}/files/{fileName}";
+        private static stampClusterAPIPath = "/api/stamps/{stampName}/cluster";
 
         // Uri Paths of Geo Region Diagnostic Role APIs
         private static baseAPIPathSites: string = "v2/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Web/sites/{site}/diagnostics";
@@ -105,6 +106,10 @@ module SupportCenter {
         public static SupportCenterTicketWorkflowPath(ticketWorkflowId: string): string {
             return UriPaths.supportCenterTicketWorflow
                 .replace("{ticketWorkflowId}", ticketWorkflowId);
+        }
+
+        public static StampClusterAPIPath(stampName: string): string {
+            return UriPaths.stampClusterAPIPath.replace("{stampName}", stampName);
         }
 
         private static CreateGeoRegionAPIPath(pathFormat: string, resource: Resource, startTime: string, endTime: string, timeGrain: string): string {

--- a/AppLensV2/app/Common/SiteService.ts
+++ b/AppLensV2/app/Common/SiteService.ts
@@ -5,8 +5,8 @@ module SupportCenter {
 
     export class SiteService implements IResourceService {
 
-        static $inject = ['$http', '$stateParams', 'ErrorHandlerService'];
-        constructor(private $http: ng.IHttpService, private $stateParams: IStateParams, private ErrorHandlerService: IErrorHandlerService) {
+        static $inject = ['$http', '$stateParams', 'ErrorHandlerService', '$q'];
+        constructor(private $http: ng.IHttpService, private $stateParams: IStateParams, private ErrorHandlerService: IErrorHandlerService, private $q: ng.IQService) {
             var self = this;
 
             if (!angular.isDefined(this.$stateParams.hostingEnvironmentName) || this.$stateParams.hostingEnvironmentName === '') {
@@ -65,5 +65,17 @@ module SupportCenter {
         public hostingEnvironment: HostingEnvironment;
         public resource: Resource;
         public sites: Site[];
+
+        public GetStampCluster(): ng.IPromise<string> {
+
+            var deferred = this.$q.defer<string>();
+            let url: string = UriPaths.StampClusterAPIPath(this.site.stampName);
+            this.$http.get(url)
+                .success((data: any) => {
+                    deferred.resolve(data);
+                });
+
+            return deferred.promise;
+        }
     }
 }


### PR DESCRIPTION
- fixes in app restart analysis
- Getting Cluster Name for a stamp. (will be using this information for deeplinking netvma tool from applens once icm work is done)
- Unblock Support sessions in case of failures from cloud es  kusto (issue #1016 ) for demo purposes