### PR TITLE
Fixing TCP Connection Warning for Linux Sites

### DIFF
--- a/AppLensV2/app/Common/AseService.ts
+++ b/AppLensV2/app/Common/AseService.ts
@@ -5,6 +5,7 @@ module SupportCenter {
 
     export interface IResourceService {
         promise: ng.IPromise<any>;
+        propertiesPromise: ng.IPromise<any>;
         site: Site;
         hostingEnvironment: HostingEnvironment;
         resource: Resource;
@@ -41,6 +42,7 @@ module SupportCenter {
         }
         
         public promise: ng.IPromise<any>;
+        public propertiesPromise: ng.IPromise<any>;
         public site: Site;
         public hostingEnvironment: HostingEnvironment;
         public resource: Resource;

--- a/AppLensV2/app/Common/SiteService.ts
+++ b/AppLensV2/app/Common/SiteService.ts
@@ -23,7 +23,7 @@ module SupportCenter {
                         self.site = self.sites[0];
                         self.resource = self.sites[0];
 
-                        self.$http({
+                        self.propertiesPromise = self.$http({
                             method: "GET",
                             url: UriPaths.DiagnosticsPassThroughAPIPath(),
                             headers: {
@@ -61,6 +61,7 @@ module SupportCenter {
         }
         
         public promise: ng.IPromise<any>;
+        public propertiesPromise: ng.IPromise<any>;
         public site: Site;
         public hostingEnvironment: HostingEnvironment;
         public resource: Resource;

--- a/AppLensV2/app/Main/main.html
+++ b/AppLensV2/app/Main/main.html
@@ -37,7 +37,7 @@
                     
                 </div>
             </md-list-item>
-            <md-list-item class="md-2-line" ng-class="{'selected' : main.selectedItem === 'tcpconnectionsanalysis'}" ng-click="main.setSelectedItem('tcpconnectionsanalysis')">
+            <md-list-item ng-if="!main.site.isLinux" class="md-2-line" ng-class="{'selected' : main.selectedItem === 'tcpconnectionsanalysis'}" ng-click="main.setSelectedItem('tcpconnectionsanalysis')">
                 <div class="md-list-item-text" layout="column">
                     <h3>TCP Connections Analysis <ng-md-icon icon="fibre_new" style="fill:#5bc0de" size="25"></ng-md-icon></h3>
 

--- a/AppLensV2/app/Site/SiteCtrl.ts
+++ b/AppLensV2/app/Site/SiteCtrl.ts
@@ -33,8 +33,12 @@ module SupportCenter {
                 self.site = self.SiteService.resource;
                 self.getRuntimeAvailability();
                 self.getSiteLatency();
-                self.getPortRejections();
-                self.getTcpConnections();
+                
+                self.SiteService.propertiesPromise.then(function (data: any) {
+                    if (!self.SiteService.site.isLinux) {
+                        self.getPortRejections();
+                        self.getTcpConnections();
+                    }
                 
                 self.DetectorsService.getDetectors(self.site).then(function (data: DetectorDefinition[]) {
                     self.detectors = self.DetectorsService.detectorsList;

--- a/AppLensV2/app/Site/SiteCtrl.ts
+++ b/AppLensV2/app/Site/SiteCtrl.ts
@@ -39,6 +39,7 @@ module SupportCenter {
                         self.getPortRejections();
                         self.getTcpConnections();
                     }
+                });
                 
                 self.DetectorsService.getDetectors(self.site).then(function (data: DetectorDefinition[]) {
                     self.detectors = self.DetectorsService.detectorsList;


### PR DESCRIPTION
1) Disabling TCP Connection Analysis for non windows sites
2) Calling the TCP detectors only for sites that are windows by checking isLinux property