### PR TITLE
Forcing to TLS 1.2

### DIFF
--- a/AppLensV2/Global.asax.cs
+++ b/AppLensV2/Global.asax.cs
@@ -12,6 +12,7 @@ namespace AppLensV2
         protected void Application_Start()
         {
             GlobalConfiguration.Configure(WebApiConfig.Register);
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
         }
     }
 }


### PR DESCRIPTION
Otherwise the georegionclient call is failing with an error 

System.Net.Http.HttpRequestException: An error occurred while sending the request. ---> System.Net.WebException: The underlying connection was closed: An unexpected error occurred on a send. ---> System.IO.IOException: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host. ---> System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host
   